### PR TITLE
Adding Twilight Forest crops to Agricraft

### DIFF
--- a/server/config/agricraft/json/defaults/mod_mysticalagriculture/plants/fiery_ingot_plant.json
+++ b/server/config/agricraft/json/defaults/mod_mysticalagriculture/plants/fiery_ingot_plant.json
@@ -1,0 +1,72 @@
+{
+  "path": "mod_mysticalagriculture/plants/fiery_ingot_plant.json",
+  "enabled": true,
+  "id": "mysticalagriculture:fiery_ingot_plant",
+  "plant_name": "Fiery Ingot",
+  "seed_name": "Fiery Ingot Seeds",
+  "seed_items": [
+    {
+      "item": "mysticalagriculture:fiery_ingot_seeds",
+      "meta": 0,
+      "tags": "",
+      "ignoreMeta": false,
+      "ignoreTags": [
+        "*"
+      ],
+      "useOreDict": false
+    }
+  ],
+  "description": {
+    "translations": {},
+    "default": "Fiery Ingot Seeds."
+  },
+  "growth_chance": 0.9,
+  "growth_bonus": 0.025,
+  "bonemeal": false,
+  "tier": 1,
+  "weedable": false,
+  "aggressive": false,
+  "spread_chance": 0.1,
+  "spawn_chance": 0.0,
+  "grass_drop_chance": 0.0,
+  "seed_drop_chance": 1.0,
+  "seed_drop_bonus": 0.0,
+  "products": {
+    "products": [
+      {
+        "min": 1,
+        "max": 5,
+        "chance": 0.9,
+        "required": true,
+        "item": "mysticalagriculture:fiery_ingot_essence",
+        "meta": 0,
+        "tags": "",
+        "ignoreMeta": false,
+        "ignoreTags": [],
+        "useOreDict": false
+      }
+    ]
+  },
+  "requirement": {
+    "min_light": 10,
+    "max_light": 16,
+    "soils": [
+      "farmland_soil"
+    ],
+    "conditions": []
+  },
+  "texture": {
+    "render_type": "cross",
+    "seed_texture": "mysticalagriculture:items/fiery_ingot_seeds",
+    "plant_textures": [
+      "mysticalagriculture:blocks/crop0",
+      "mysticalagriculture:blocks/crop1",
+      "mysticalagriculture:blocks/crop2",
+      "mysticalagriculture:blocks/crop2",
+      "mysticalagriculture:blocks/crop3",
+      "mysticalagriculture:blocks/crop4",
+      "mysticalagriculture:blocks/crop4",
+      "mysticalagriculture:blocks/fiery_ingot_crop"
+    ]
+  }
+}

--- a/server/config/agricraft/json/defaults/mod_mysticalagriculture/plants/ironwood_plant.json
+++ b/server/config/agricraft/json/defaults/mod_mysticalagriculture/plants/ironwood_plant.json
@@ -1,0 +1,72 @@
+{
+  "path": "mod_mysticalagriculture/plants/ironwood_plant.json",
+  "enabled": true,
+  "id": "mysticalagriculture:ironwood_plant",
+  "plant_name": "Ironwood Crop",
+  "seed_name": "Ironwood Seeds",
+  "seed_items": [
+    {
+      "item": "mysticalagriculture:ironwood_seeds",
+      "meta": 0,
+      "tags": "",
+      "ignoreMeta": false,
+      "ignoreTags": [
+        "*"
+      ],
+      "useOreDict": false
+    }
+  ],
+  "description": {
+    "translations": {},
+    "default": "Ironwood Seeds."
+  },
+  "growth_chance": 0.9,
+  "growth_bonus": 0.025,
+  "bonemeal": false,
+  "tier": 1,
+  "weedable": false,
+  "aggressive": false,
+  "spread_chance": 0.1,
+  "spawn_chance": 0.0,
+  "grass_drop_chance": 0.0,
+  "seed_drop_chance": 1.0,
+  "seed_drop_bonus": 0.0,
+  "products": {
+    "products": [
+      {
+        "min": 1,
+        "max": 5,
+        "chance": 0.9,
+        "required": true,
+        "item": "mysticalagriculture:ironwood_essence",
+        "meta": 0,
+        "tags": "",
+        "ignoreMeta": false,
+        "ignoreTags": [],
+        "useOreDict": false
+      }
+    ]
+  },
+  "requirement": {
+    "min_light": 10,
+    "max_light": 16,
+    "soils": [
+      "farmland_soil"
+    ],
+    "conditions": []
+  },
+  "texture": {
+    "render_type": "cross",
+    "seed_texture": "mysticalagriculture:items/ironwood_seeds",
+    "plant_textures": [
+      "mysticalagriculture:blocks/crop0",
+      "mysticalagriculture:blocks/crop1",
+      "mysticalagriculture:blocks/crop2",
+      "mysticalagriculture:blocks/crop2",
+      "mysticalagriculture:blocks/crop3",
+      "mysticalagriculture:blocks/crop4",
+      "mysticalagriculture:blocks/crop4",
+      "mysticalagriculture:blocks/ironwood_crop"
+    ]
+  }
+}

--- a/server/config/agricraft/json/defaults/mod_mysticalagriculture/plants/knightmetal_plant.json
+++ b/server/config/agricraft/json/defaults/mod_mysticalagriculture/plants/knightmetal_plant.json
@@ -1,0 +1,72 @@
+{
+  "path": "mod_mysticalagriculture/plants/knightmetal_plant.json",
+  "enabled": true,
+  "id": "mysticalagriculture:knightmetal_plant",
+  "plant_name": "Knightmetal Crop",
+  "seed_name": "Knightmetal Seeds",
+  "seed_items": [
+    {
+      "item": "mysticalagriculture:knightmetal_seeds",
+      "meta": 0,
+      "tags": "",
+      "ignoreMeta": false,
+      "ignoreTags": [
+        "*"
+      ],
+      "useOreDict": false
+    }
+  ],
+  "description": {
+    "translations": {},
+    "default": "Knightmetal Seeds."
+  },
+  "growth_chance": 0.9,
+  "growth_bonus": 0.025,
+  "bonemeal": false,
+  "tier": 1,
+  "weedable": false,
+  "aggressive": false,
+  "spread_chance": 0.1,
+  "spawn_chance": 0.0,
+  "grass_drop_chance": 0.0,
+  "seed_drop_chance": 1.0,
+  "seed_drop_bonus": 0.0,
+  "products": {
+    "products": [
+      {
+        "min": 1,
+        "max": 5,
+        "chance": 0.9,
+        "required": true,
+        "item": "mysticalagriculture:knightmetal_essence",
+        "meta": 0,
+        "tags": "",
+        "ignoreMeta": false,
+        "ignoreTags": [],
+        "useOreDict": false
+      }
+    ]
+  },
+  "requirement": {
+    "min_light": 10,
+    "max_light": 16,
+    "soils": [
+      "farmland_soil"
+    ],
+    "conditions": []
+  },
+  "texture": {
+    "render_type": "cross",
+    "seed_texture": "mysticalagriculture:items/knightmetal_seeds",
+    "plant_textures": [
+      "mysticalagriculture:blocks/crop0",
+      "mysticalagriculture:blocks/crop1",
+      "mysticalagriculture:blocks/crop2",
+      "mysticalagriculture:blocks/crop2",
+      "mysticalagriculture:blocks/crop3",
+      "mysticalagriculture:blocks/crop4",
+      "mysticalagriculture:blocks/crop4",
+      "mysticalagriculture:blocks/knightmetal_crop"
+    ]
+  }
+}

--- a/server/config/agricraft/json/defaults/mod_mysticalagriculture/plants/steeleaf_plant.json
+++ b/server/config/agricraft/json/defaults/mod_mysticalagriculture/plants/steeleaf_plant.json
@@ -1,0 +1,72 @@
+{
+  "path": "mod_mysticalagriculture/plants/steeleaf_plant.json",
+  "enabled": true,
+  "id": "mysticalagriculture:steeleaf_plant",
+  "plant_name": "Steeleaf Crop",
+  "seed_name": "Steeleaf Seeds",
+  "seed_items": [
+    {
+      "item": "mysticalagriculture:steeleaf_seeds",
+      "meta": 0,
+      "tags": "",
+      "ignoreMeta": false,
+      "ignoreTags": [
+        "*"
+      ],
+      "useOreDict": false
+    }
+  ],
+  "description": {
+    "translations": {},
+    "default": "Steeleaf Seeds."
+  },
+  "growth_chance": 0.9,
+  "growth_bonus": 0.025,
+  "bonemeal": false,
+  "tier": 1,
+  "weedable": false,
+  "aggressive": false,
+  "spread_chance": 0.1,
+  "spawn_chance": 0.0,
+  "grass_drop_chance": 0.0,
+  "seed_drop_chance": 1.0,
+  "seed_drop_bonus": 0.0,
+  "products": {
+    "products": [
+      {
+        "min": 1,
+        "max": 5,
+        "chance": 0.9,
+        "required": true,
+        "item": "mysticalagriculture:steeleaf_essence",
+        "meta": 0,
+        "tags": "",
+        "ignoreMeta": false,
+        "ignoreTags": [],
+        "useOreDict": false
+      }
+    ]
+  },
+  "requirement": {
+    "min_light": 10,
+    "max_light": 16,
+    "soils": [
+      "farmland_soil"
+    ],
+    "conditions": []
+  },
+  "texture": {
+    "render_type": "cross",
+    "seed_texture": "mysticalagriculture:items/steeleaf_seeds",
+    "plant_textures": [
+      "mysticalagriculture:blocks/crop0",
+      "mysticalagriculture:blocks/crop1",
+      "mysticalagriculture:blocks/crop2",
+      "mysticalagriculture:blocks/crop2",
+      "mysticalagriculture:blocks/crop3",
+      "mysticalagriculture:blocks/crop4",
+      "mysticalagriculture:blocks/crop4",
+      "mysticalagriculture:blocks/steeleaf_crop"
+    ]
+  }
+}


### PR DESCRIPTION
Adding JSON files to allow the Twilight Forest crops that are under Mystical Agriculture (Fiery Ingot, Ironwood, Knightmetal, Steeleaf) to be planted in Agricraft crop sticks.