### PR TITLE
Disabling Hunger Overhaul's stack sizes and adding OpenBlocks config

### DIFF
--- a/server/config/hungeroverhaul/HungerOverhaul.cfg
+++ b/server/config/hungeroverhaul/HungerOverhaul.cfg
@@ -138,7 +138,7 @@ food {
     B:modifyFoodEatingSpeed=true
 
     # Changes the stack size of food to be dependant on the food's replenishment value [vanilla: false] [default: true]
-    B:modifyFoodStackSize=true
+    B:modifyFoodStackSize=false
 
     # Enables/disables all food value modification [vanilla: false] [default: true]
     B:modifyFoodValues=true

--- a/server/config/openblocks.cfg
+++ b/server/config/openblocks.cfg
@@ -1,0 +1,512 @@
+# Configuration file
+
+additional {
+    # List any mob names (like 'minecraft:bat') you want disabled on the server
+    S:disableMobNames <
+     >
+
+    # Should player inventories be stored after death (can be later restored with ob_inventory command)
+    B:dumpDeadPlayersInventories=true
+}
+
+
+blocks {
+    B:auto_anvil=true
+    B:auto_enchantment_table=true
+    B:beartrap=true
+    B:big_button=true
+    B:big_button_wood=true
+    B:block_breaker=true
+    B:block_placer=true
+    B:builder_guide=true
+    B:cannon=true
+    B:canvas=true
+    B:canvas_glass=true
+    B:donation_station=true
+    B:drawing_table=true
+    B:elevator=true
+    B:elevator_rotating=true
+    B:fan=true
+    B:flag=true
+    B:golden_egg=true
+    B:grave=true
+    B:guide=true
+    B:heal=true
+    B:imaginary=true
+    B:item_dropper=true
+    B:ladder=true
+    B:paint_can=true
+    B:paint_mixer=true
+    B:path=true
+    B:projector=true
+    B:rope_ladder=true
+    B:scaffolding=true
+    B:sky=true
+    B:sponge=true
+    B:sprinkler=true
+    B:tank=false
+    B:target=true
+    B:trophy=true
+    B:vacuum_hopper=true
+    B:village_highlighter=true
+    B:xp_bottler=true
+    B:xp_drain=true
+    B:xp_shower=true
+}
+
+
+breaker {
+    # Maximum number of actions that can be performed by block breaker in single tick
+    I:actionLimit=16
+}
+
+
+canvas {
+    # Controls number of textures allocated for canvas. Increase if canvas blocks stop rendering properly (get empty sides). To re-apply, reload textures
+    I:canvasTexturePoolSize=256
+
+    # If true, paintbrush will replace suitable blocks with canvas. Otherwise, it will only try to paint blocks
+    B:paintbrushReplacesBlocks=true
+
+    # List of block ids that should not be replaceable by canvas (by using brush, stencil, etc)
+    S:replaceBlacklist <
+     >
+}
+
+
+cartographer {
+    # List of blocks that should be invisible to cartographer. Example: id:3,  OpenBlocks:openblocks_radio (case sensitive)
+    S:blockBlacklist <
+     >
+
+    # Should invalid height map request be always reported
+    B:reportInvalidRequest=false
+}
+
+
+crane {
+    # Enable magnet turtles
+    B:addTurtles=true
+
+    # Use shift to control crane direction (otherwise, toggle every time)
+    B:boringMode=true
+
+    # Enable collision checking of crane arm
+    B:doCraneCollisionCheck=false
+
+    # List of resource location names of blocks that can be picked by magnet
+    S:magnetBlockWhitelist <
+     >
+
+    # List of resource location names of entities that can be picked by magnet
+    S:magnetEntityWhitelist <
+     >
+
+    # List of resource location names of tile entities that can be picked by magnet
+    S:magnetTileEntityWhitelist <
+     >
+
+    # Show magnet turtles in creative list
+    B:showTurtles=true
+
+    # Maximal distance from turtle to magnet when deactivating
+    D:turtleMagnetDeactivateRange=3.0
+
+    # Range of magnet CC peripheral
+    D:turtleMagnetRange=32.0
+}
+
+
+cursor {
+    # Maximum distance cursor can reach (warning: increasing may cause crashes)
+    I:cursorMaxDistance=64
+}
+
+
+debug {
+    # Show structures found by golden eye
+    B:goldenEyeDebug=false
+
+    # Dump extra amount of data, every time grave is created
+    B:gravesDebug=false
+}
+
+
+devnull {
+    # Color of contained stack size in GUI
+    I:countColor=16776960
+
+    # If true, /dev/null will require sneaking in addition to clicking air to open gui
+    B:sneakClickToGui=true
+}
+
+
+dropblock {
+    # Should elevator move player to center of block after teleporting	
+    B:centerOnBlock=false
+
+    # XP consumed by elevator (total amount = ratio * distance)
+    D:elevatorXpDrainRatio=0.0
+
+    # Disable limit of blocks between elevators (equivalent to maxPassThrough = infinity)
+    B:ignoreAllBlocks=false
+
+    # The elevator will ignore half blocks when counting the blocks it can pass through
+    B:ignoreHalfBlocks=false
+
+    # The elevator will try to pass through blocks that have custom collision boxes
+    B:irregularBlocksArePassable=true
+
+    # The maximum amount of blocks the elevator can pass through before the teleport fails
+    I:maxPassThrough=4
+
+    # Use to configure blocks as elevators. Examples: 'minecraft:wool' - configure any wool as white elevator, 'minecraft:wool#color=light_blue;yellow' - configure lightblue wool as yellow elevator
+    S:overrides <
+     >
+
+    # The range of the drop block
+    I:searchDistance=20
+
+    # Defines blocks that are handled specially by elevators. Entries are in form <modId>:<blockName>:<action> or id:<blockId>:<action>. Possible actions: abort (elevator can't pass block), increment (counts for elevatorMaxBlockPassCount limit) and ignore
+    S:specialBlockRules <
+     >
+}
+
+
+egg {
+    # Can golden egg pick blocks while hatching (may lead to glitches)
+    B:pickBlocks=true
+}
+
+
+fan {
+    # Maximum force applied every tick to entities nearby (linear decay)
+    D:fanForce=0.05
+
+    # Range of fan in blocks
+    D:fanRange=10.0
+
+    # Is fan force controlled by redstone current
+    B:isRedstoneActivated=true
+}
+
+
+features {
+    # Other fluids accepted instead liquid XP
+    S:additionalXpFluids <
+        "experience:20"
+     >
+
+    # Explosive enchant can break blocks at level 3
+    B:explosiveEnchantGrief=true
+
+    # Is 'Explosive' enchantment enabled
+    B:explosiveEnchantment=true
+
+    # Is  'Flim-flam' enchantment enabled
+    B:flimFlamEnchantment=true
+
+    # Should every player get info book on first login
+    B:infoBook=true
+
+    # Is 'Last Stand' enchantment enabled
+    B:lastStandEnchantment=true
+
+    # Formula for XP cost (variables: hp,dmg,ench,xp). Note: calculation only triggers when hp - dmg < 1.
+    S:lastStandFormula=max(1, 50*(1-(hp-dmg))/ench)
+
+    # Storage in mB needed to store single XP point
+    I:xpToLiquidRatio=20
+}
+
+
+glasses {
+    # 0.0 - no visible change to world, 1.0 - world fully obscured
+    D:opacity=0.7
+
+    # Use texture for obscuring world
+    B:useTexture=true
+}
+
+
+glyphs {
+    # Should glyphs be added to creative search GUI
+    B:showInCreativeSearch=false
+}
+
+
+graves {
+    # Can grave spawn single block of dirt when it has no block under?
+    B:canSpawnBase=true
+
+    # Try to overwrite blocks with graves if no suitable place is found on first try
+    B:destructiveGraves=false
+
+    # Maximal height where grave should be spawned (default value selected to prevent spawning in bedrock)
+    I:maximalPosY=249
+
+    # Minimal height where grave should be spawned (default value selected to prevent spawning in bedrock)
+    I:minimalPosY=6
+
+    # Require gravestone to be in a player's inventory (it is consumed)
+    B:requiresGraveInInv=false
+
+    # Spawn rate, range: 0..1, default: about 1 per 50s
+    D:skeletonSpawnRate=0.002
+
+    # Size of cube searched for spaces suitable for grave spawning
+    I:spawnRange=10
+
+    # Should grave randomly spawn skeletons
+    B:spawnSkeletons=true
+
+    # Frequency of special action on grave digging, 0..1
+    D:specialActionFrequency=0.03
+
+    # Store contents of spawned graves into separate NBT files (can later be restored with ob_inventory command)
+    B:storeContents=true
+}
+
+
+guide {
+    # How builder guide should react to redstone. 0 - not sensitive, 1 - powered == on, -1 - inverted
+    I:redstoneSensitivity=1
+
+    # Square of guide maximum render distance
+    D:renderDistanceSq=65536.0
+
+    # Try to use advanced OpenGL for performance improvement
+    B:useAdvancedRenderer=true
+}
+
+
+hacks {
+    # Enable experimental features that may be buggy or broken entirely
+    B:enableExperimentalFeatures=false
+}
+
+
+hangglider {
+    # Enable a whole new level of hanggliding experience through thermal lift. See keybindings for acoustic vario controls
+    B:enableThermal=true
+}
+
+
+imaginary {
+    # Speed of imaginary blocks fading/appearing
+    D:fadingSpeed=0.0075
+
+    # Number of newly created crayon/pencil uses
+    D:numberOfUses=10.0
+}
+
+
+itemdropper {
+    # Maximum speed that can be set in item dropper GUI
+    D:maxItemDropSpeed=4.0
+}
+
+
+items {
+    B:cartographer=true
+    B:crane_backpack=true
+    B:crane_control=true
+    B:crayon_glasses=true
+    B:cursor=true
+    B:dev_null=true
+    B:empty_map=true
+    B:epic_eraser=true
+    B:generic=true
+    B:generic_unstackable=true
+    B:glyph=true
+    B:golden_eye=true
+    B:hang_glider=true
+    B:height_map=true
+    B:info_book=true
+    B:luggage=true
+    B:paintbrush=true
+    B:pedometer=true
+    B:pencil_glasses=true
+    B:serious_glasses=true
+    B:sleeping_bag=true
+    B:slimalyzer=true
+    B:sonic_glasses=true
+    B:sponge_on_a_stick=true
+    B:squeegee=true
+    B:stencil=true
+    B:tasty_clay=true
+    B:technicolor_glasses=true
+    B:wrench=true
+    B:xp_bucket=true
+}
+
+
+ladder {
+    # If true, ladders will behave in old way: single item will place ladder all the way down, but it will not drop when broken
+    B:infiniteMode=false
+}
+
+
+loot {
+    B:technicolorGlasses=true
+}
+
+
+magnet {
+    # Can crane magnet pick block?
+    B:pickBlocks=true
+
+    # Can crane magnet pick entities?
+    B:pickEntities=true
+}
+
+
+placer {
+    # Maximum number of actions that can be performed by block placer in single tick
+    I:actionLimit=16
+}
+
+
+projector {
+    # The projector's cone will use the specified brightness value to render.
+    # Value must be between 0 and 255 inclusive. To use the default world brightness set -1 as the value.
+    # Keep in mind that default brightness means that the cone will render as light blue during the day and dark blue during the night.
+    I:brightness=-1
+
+    # Level of light emitted by the active projector. Defaults to 10. Must be at maximum 15 and positive
+    I:lightLevel=10
+
+    # Projector will light up whenever it is displaying a map
+    B:lightUpWhenWorking=true
+
+    # Projector will render a holographic cone whenever active
+    B:renderHolographicCone=true
+}
+
+
+radio {
+    # Should add radio villager profession
+    B:radioVillagerEnabled=true
+}
+
+
+scaffolding {
+    # The rate at which scaffolding should break. 0 - fastest
+    I:despawnRate=4
+}
+
+
+skyblock {
+    # Forces skyblock rendering even when Optifine is enabled (warning: skyblocks may be incompatible with shaders!)
+    B:optifineOverride=false
+
+    # Enables skyblock rendering. Disable when there are graphic glitches or performance problems. Requires resource reload after change.
+    B:renderingEnabled=true
+}
+
+
+sponge {
+    # Should sponge block update neighbours after liquid removal?
+    B:blockUpdate=false
+
+    # Sponge block range (distance from center)
+    I:spongeRange=3
+
+    # SpongeOnAStick use count
+    I:spongeStickUseCount=256
+
+    # Should sponge-on-a-stick update neighbours after liquid removal?
+    B:stickBlockUpdate=false
+}
+
+
+sprinkler {
+    # Consume rate of bonemeal (ticks/item).
+    I:bonemealConsumeRate=600
+
+    # 1/chance that crops will be fertilized with bonemeal
+    I:bonemealFertilizeChance=200
+
+    # The range in each cardinal direction that crops will be affected.
+    I:effectiveRange=4
+
+    # 1/chance that crops will be fertilized without bonemeal
+    I:fertilizeChance=500
+
+    # Capacity (in mB) of internal tank.
+    I:internalTankCapacity=50
+
+    # Consume rate of sprinkler (ticks/mB).
+    I:waterConsumeRate=20
+}
+
+
+tanks {
+    # Can buckets be filled directly from tank? (works only for vanilla fluids, universal bucket and ones registered in 'bucketItems')
+    B:allowBucketDrain=true
+
+    # List of additional custom buckets than can be filled directly from tanks
+    S:bucketItems <
+        "openblocks:xp_bucket"
+     >
+
+    # The amount of buckets each tank can hold
+    I:bucketsPerTank=16
+
+    # Should filled tanks be searchable with creative menu
+    B:displayAllFluids=true
+
+    # Tanks will emit light when they contain a liquid that glows (eg. lava)
+    B:emitLight=true
+
+    # Minimal difference in fluid level between neigbors required for tank update (can be used for performance finetuning
+    I:fluidDifferenceUpdateThreshold=0
+
+    # Should tanks try to balance liquid amounts with neighbours
+    B:tankTicks=true
+}
+
+
+tomfoolery {
+    # You know, THAT thing! That you shouldn't do in public!
+    B:doItWhileTyping=false
+
+    # Blacklist/Whitelist for effects used by flim-flam enchantment
+    S:flimFlamBlacklist <
+     >
+
+    # If true, flim-flam blacklist will become whitelist
+    B:reverseBlacklist=false
+
+    # Allow only flimflams that don't cause death (or at least very rarely)
+    B:safeOnly=false
+
+    # 0 - lore hidden, 1 - visible only with pressed ALT, 2 - always visible
+    I:sillyLoreDisplay=1
+
+    # Are you serious too?
+    B:weAreSeriousPeople=true
+}
+
+
+trophy {
+    # Legacy value. For actual configuration, see 'trophyDropChanceFormula'
+    D:trophyDropChance=0.001
+
+    # Formula for calculating trophy drop chance. Trophy drops when result is positive.
+    S:trophyDropChanceFormula=let([bias=rand()/4, selection=rand()], (looting + bias) * chance - selection)
+}
+
+
+xpbucket {
+    # Can bucket be filled with liquid XP directly from any source?
+    B:directFill=true
+
+    # Should XP bucket be shown in inventory (if this is set, while universal bucket is enabled and registerUniversalXpBucket is set, creative menu will contain two buckets containing liquid XP)
+    B:showInCreativeGui=true
+
+    # Should liquid XP be registered for universal bucket support (does not enable universal bucket)
+    B:universalBucketSupport=true
+}
+
+


### PR DESCRIPTION
Disabling Hunger Overhaul's modification of food stack sizes and adding OpenBlocks config with Tanks disabled.