### PR TITLE
Adding Thaumium and Elementium plants to Agricraft

### DIFF
--- a/server/config/agricraft/json/defaults/mod_mysticalagriculture/plants/elementium_plant.json
+++ b/server/config/agricraft/json/defaults/mod_mysticalagriculture/plants/elementium_plant.json
@@ -1,0 +1,72 @@
+{
+  "path": "mod_mysticalagriculture/plants/elementium_plant.json",
+  "enabled": true,
+  "id": "mysticalagriculture:elementium_plant",
+  "plant_name": "Elementium Crop",
+  "seed_name": "Elementium Seeds",
+  "seed_items": [
+    {
+      "item": "mysticalagriculture:elementium_seeds",
+      "meta": 0,
+      "tags": "",
+      "ignoreMeta": false,
+      "ignoreTags": [
+        "*"
+      ],
+      "useOreDict": false
+    }
+  ],
+  "description": {
+    "translations": {},
+    "default": "Elementium Seeds."
+  },
+  "growth_chance": 0.9,
+  "growth_bonus": 0.025,
+  "bonemeal": false,
+  "tier": 1,
+  "weedable": false,
+  "aggressive": false,
+  "spread_chance": 0.1,
+  "spawn_chance": 0.0,
+  "grass_drop_chance": 0.0,
+  "seed_drop_chance": 1.0,
+  "seed_drop_bonus": 0.0,
+  "products": {
+    "products": [
+      {
+        "min": 1,
+        "max": 5,
+        "chance": 0.9,
+        "required": true,
+        "item": "mysticalagriculture:elementium_essence",
+        "meta": 0,
+        "tags": "",
+        "ignoreMeta": false,
+        "ignoreTags": [],
+        "useOreDict": false
+      }
+    ]
+  },
+  "requirement": {
+    "min_light": 10,
+    "max_light": 16,
+    "soils": [
+      "farmland_soil"
+    ],
+    "conditions": []
+  },
+  "texture": {
+    "render_type": "cross",
+    "seed_texture": "mysticalagriculture:items/elementium_seeds",
+    "plant_textures": [
+      "mysticalagriculture:blocks/crop0",
+      "mysticalagriculture:blocks/crop1",
+      "mysticalagriculture:blocks/crop2",
+      "mysticalagriculture:blocks/crop2",
+      "mysticalagriculture:blocks/crop3",
+      "mysticalagriculture:blocks/crop4",
+      "mysticalagriculture:blocks/crop4",
+      "mysticalagriculture:blocks/elementium_crop"
+    ]
+  }
+}

--- a/server/config/agricraft/json/defaults/mod_mysticalagriculture/plants/thaumium_plant.json
+++ b/server/config/agricraft/json/defaults/mod_mysticalagriculture/plants/thaumium_plant.json
@@ -1,0 +1,72 @@
+{
+  "path": "mod_mysticalagriculture/plants/thaumium_plant.json",
+  "enabled": true,
+  "id": "mysticalagriculture:thaumium_plant",
+  "plant_name": "Thaumium Crop",
+  "seed_name": "Thaumium Seeds",
+  "seed_items": [
+    {
+      "item": "mysticalagriculture:thaumium_seeds",
+      "meta": 0,
+      "tags": "",
+      "ignoreMeta": false,
+      "ignoreTags": [
+        "*"
+      ],
+      "useOreDict": false
+    }
+  ],
+  "description": {
+    "translations": {},
+    "default": "Thaumium Seeds."
+  },
+  "growth_chance": 0.9,
+  "growth_bonus": 0.025,
+  "bonemeal": false,
+  "tier": 1,
+  "weedable": false,
+  "aggressive": false,
+  "spread_chance": 0.1,
+  "spawn_chance": 0.0,
+  "grass_drop_chance": 0.0,
+  "seed_drop_chance": 1.0,
+  "seed_drop_bonus": 0.0,
+  "products": {
+    "products": [
+      {
+        "min": 1,
+        "max": 5,
+        "chance": 0.9,
+        "required": true,
+        "item": "mysticalagriculture:thaumium_essence",
+        "meta": 0,
+        "tags": "",
+        "ignoreMeta": false,
+        "ignoreTags": [],
+        "useOreDict": false
+      }
+    ]
+  },
+  "requirement": {
+    "min_light": 10,
+    "max_light": 16,
+    "soils": [
+      "farmland_soil"
+    ],
+    "conditions": []
+  },
+  "texture": {
+    "render_type": "cross",
+    "seed_texture": "mysticalagriculture:items/thaumium_seeds",
+    "plant_textures": [
+      "mysticalagriculture:blocks/crop0",
+      "mysticalagriculture:blocks/crop1",
+      "mysticalagriculture:blocks/crop2",
+      "mysticalagriculture:blocks/crop2",
+      "mysticalagriculture:blocks/crop3",
+      "mysticalagriculture:blocks/crop4",
+      "mysticalagriculture:blocks/crop4",
+      "mysticalagriculture:blocks/thaumium_crop"
+    ]
+  }
+}


### PR DESCRIPTION
Adding Thaumium and Elementium plants (from Mystical Agriculture) to Agricraft so they can be planted in crop sticks.